### PR TITLE
Add details around Apps Manager, Search Server, and Invitations configurable buildpacks

### DIFF
--- a/custom-branding.html.md.erb
+++ b/custom-branding.html.md.erb
@@ -58,11 +58,11 @@ To customize your Apps Manager interface:
 1. By default, Apps Manager includes three sidebar links: **Marketplace**, **Docs**, and **Tools**. You can edit existing sidebar links by clicking the name of the link and editing the **Link text** and **URL** fields. You can also remove the link by clicking the trash icon next to its name. If you want to add a new sidebar link, click **Add** and complete the **Link text** and **URL** fields.
 	<p class="note"><strong>Note:</strong> Removing any of the default links will remove them from the sidebar for all users.</p>
 
-1. For **Apps Manager Buildpack**, enter a static content compatible buildpack to be used when deploying the Apps Manager app. By default, this will be the `staticfile_buildpack`.
+1. For **Apps Manager Buildpack**, enter a static content-compatible buildpack you want <%= vars.app_runtime_abbr %> to use when deploying the Apps Manager app. By default, this is `staticfile_buildpack`.
 
-1. For **Search Server Buildpack**, enter a nodejs compatible buildpack to be used when deploying the Search Server app. By default, this will be the `nodejs_buildpack`.
+1. For **Search Server Buildpack**, enter a Node.js-compatible buildpack you want <%= vars.app_runtime_abbr %> to use when deploying the Search Server app. By default, this is `nodejs_buildpack`.
 
-1. For **Invitations Buildpack**, enter a nodejs compatible buildpack to be used when deploying the Invitations app. By default, this will be the `nodejs_buildpack`.
+1. For **Invitations Buildpack**, enter a Node.js-compatible buildpack you want <%= vars.app_runtime_abbr %> to use when deploying the Invitations app. By default, this is `nodejs_buildpack`.
 
 1. (Optional) Enter in MB your desired **Apps Manager memory usage**. The minimum number you can enter is `128`. Leave this field blank to use the default value of 128&nbsp;MB.
 

--- a/custom-branding.html.md.erb
+++ b/custom-branding.html.md.erb
@@ -58,7 +58,15 @@ To customize your Apps Manager interface:
 1. By default, Apps Manager includes three sidebar links: **Marketplace**, **Docs**, and **Tools**. You can edit existing sidebar links by clicking the name of the link and editing the **Link text** and **URL** fields. You can also remove the link by clicking the trash icon next to its name. If you want to add a new sidebar link, click **Add** and complete the **Link text** and **URL** fields.
 	<p class="note"><strong>Note:</strong> Removing any of the default links will remove them from the sidebar for all users.</p>
 
+1. For **Apps Manager Buildpack**, enter a static content compatible buildpack to be used when deploying the Apps Manager app. By default, this will be the `staticfile_buildpack`.
+
+1. For **Search Server Buildpack**, enter a nodejs compatible buildpack to be used when deploying the Search Server app. By default, this will be the `nodejs_buildpack`.
+
+1. For **Invitations Buildpack**, enter a nodejs compatible buildpack to be used when deploying the Invitations app. By default, this will be the `nodejs_buildpack`.
+
 1. (Optional) Enter in MB your desired **Apps Manager memory usage**. The minimum number you can enter is `128`. Leave this field blank to use the default value of 128&nbsp;MB.
+
+1. (Optional) Enter in MB your desired **Search Server memory usage**. This is the memory limit used to deploy the Search Server app. The minimum number you can enter is `256`. Leave this field blank to use the default value of 256&nbsp;MB.
 
 1. (Optional) Enter in MB your desired **Invitations memory usage**. This is the memory limit used to deploy the Invitations app. The minimum number you can enter is `256`. Leave this field blank to use the default value of 256&nbsp;MB.
 


### PR DESCRIPTION
- and add configurability of Search Server memory usage
- note that this change is only relevant in PAS 2.9 and up