### PR TITLE
Update config-proxy.html.md.erb

### DIFF
--- a/config-proxy.html.md.erb
+++ b/config-proxy.html.md.erb
@@ -39,7 +39,9 @@ To globally configure proxy settings for <%= vars.platform_name %> apps:
     Where:
     * `http_proxy`: Set this value to the proxy to use for HTTP requests.
     * `https_proxy`: Set this value to the proxy to use for HTTPS requests. In most cases, this is the same as `http_proxy`.
-    * `no_proxy`: Set this value to a comma-separated list of DNS names or IP addresses that can be accessed without passing through the proxy. This value may not be needed, because it depends on your proxy configuration. From now on, the proxy settings are applied to staging apps.
+    * `no_proxy`: Set this value to a comma-separated list of DNS suffixes or IP addresses that can be accessed without passing through the proxy.  Minimally, this value should contain the domain `.cf.internal`, which is used by the platform to communicate with CredHub.
+
+    From now on, the proxy settings are applied to apps during staging.
 
 1. To configure proxy access for apps that are running, run:
 

--- a/config-proxy.html.md.erb
+++ b/config-proxy.html.md.erb
@@ -39,7 +39,7 @@ To globally configure proxy settings for <%= vars.platform_name %> apps:
     Where:
     * `http_proxy`: Set this value to the proxy to use for HTTP requests.
     * `https_proxy`: Set this value to the proxy to use for HTTPS requests. In most cases, this is the same as `http_proxy`.
-    * `no_proxy`: Set this value to a comma-separated list of DNS suffixes or IP addresses that can be accessed without passing through the proxy.  Minimally, this value should contain the domain `.cf.internal`, which is used by the platform to communicate with CredHub.
+    * `no_proxy`: Set this value to a comma-separated list of DNS suffixes or IP addresses that can be accessed without passing through the proxy. <%= vars.recommended_by %> recommends this value contains the domain `.cf.internal`, which is used by the platform to communicate with CredHub.
 
     From now on, the proxy settings are applied to apps during staging.
 


### PR DESCRIPTION
Clarify no_proxy instructions so that customers do not block access to credhub when they set up proxy variables for their CF applications.
[#163439742](https://www.pivotaltracker.com/story/show/163439742)
[#170880034](https://www.pivotaltracker.com/story/show/170880034)