### PR TITLE
Update installing-pcf-is.html.md.erb

### DIFF
--- a/installing-pcf-is.html.md.erb
+++ b/installing-pcf-is.html.md.erb
@@ -169,8 +169,8 @@ To configure the **Compute and Networking Isolation** pane:
     <p class='note'><strong>Note:</strong> If you disable compute isolation, you must set <strong>Router sharding mode</strong> to <strong>No Isolation Segment</strong>.</p>
 
 1. Enable or disable networking isolation by selecting a sharding mode under **Router sharding mode**. For more information, see the [Sharding Routers for Isolation Segments](../adminguide/routing-is.html#sharding-routers-isolation-segment) section of the _Routing for Isolation Segments_ topic.
-  * **Isolation Segment only**: The routers for the tile acknowledge requests only from apps deployed within the Diego Cells of the tile. All other requests fail.
-  * **No Isolation Segment**: The routers for the tile reject requests for any isolation segment. Choose this option to add a group of routers for the PAS tile, such as when you want a private point of entry for the system domain.
+  * **Isolation Segment only**: The routers for the tile acknowledge requests only for apps deployed within the Diego Cells of the tile. All other requests fail.
+  * **No Isolation Segment**: The routers for the tile reject requests for any isolation segment. Choose this option to add a group of routers for the PAS tile, such as when you want a private point of entry for the system domain or configure a group of routers to receive requests from your corporate intranet.
 
 ### <a id='after_config'></a> After Tile Configuration
 


### PR DESCRIPTION
My pair and I thought that these two points more clearly explain the Iso seg only/no isolation segment option:
- the apps are the destination of traffic, not the source
- The system domain is not special, though this is a common usage of this option, so we wanted to provide an additional example for why you might choose to use isolation segments to deploy routers that don't route to the isolation segment's diego cells.