### PR TITLE
Add caveat that isolation segment is created by smoke tests

### DIFF
--- a/installing-pcf-is.html.md.erb
+++ b/installing-pcf-is.html.md.erb
@@ -178,7 +178,7 @@ To configure the **Compute and Networking Isolation** pane:
 
 After you configure the <%= vars.segment_runtime_full %> tile:
 
-1. Create the isolation segment in the Cloud Controller database (CCDB) by following the procedure in the [Create an Isolation Segment](../adminguide/isolation-segments.html#create-an-is) section of the _Managing Isolation Segments_ topic.
+1. Create the isolation segment in the Cloud Controller database (CCDB) by following the procedure in the [Create an Isolation Segment](../adminguide/isolation-segments.html#create-an-is) section of the _Managing Isolation Segments_ topic. <p class='note'><strong>Note:</strong> If you have previously run the smoke tests as a post deployment errand, the isolation segment may have already been created for you.</p>
 
 1. Return to the Ops Manager Installation Dashboard.
 


### PR DESCRIPTION
If the smoke-tests are run as a post-install errand, they will create the isolation-segment in the CCDB for the user/admin.

Related:
https://www.pivotaltracker.com/story/show/170346178
https://github.com/pivotal/pas-requests/issues/703
https://pcf.aha.io/features/ERT-733