### PR TITLE
Comma sign is added by mistake

### DIFF
--- a/configure-multi-foundation.html.md.erb
+++ b/configure-multi-foundation.html.md.erb
@@ -35,7 +35,7 @@ To configure multi-foundation support in Apps Manager:
 	    "logoutUrl": "https://login.FOUNDATION_SYSTEM_DOMAIN.com/logout.do",
 	    "metricsUrl": "https://metrics.FOUNDATION_SYSTEM_DOMAIN.com",
 	    "uaaUrl": "https://login.FOUNDATION_SYSTEM_DOMAIN.com"
-	  },
+	  }
     }
 	</pre>
 	Where:


### PR DESCRIPTION
At the end of JSON object format for Multi-foundation configuration, comma sign (",") is added by mistake. The customer follows this wrong format to configure Multi-foundation configuration, then it simply finish Apply Changes with the following kind of error.
```
Task 1374  102135  Preparing deployment Rendering templates (000043)
                    L Error Unable to render instance groups for deployment. Errors are
 - Unable to render jobs for instance group 'backup_restore'. Errors are
   - Unable to render templates for job 'push-apps-manager'. Errors are
     - Error filling in template 'bpm.yml.erb' (line 35 767 unexpected token at '{
       pcf-dev-foundation {
         ccUrl httpsapi.FOUNDATION_SYSTEM_DOMAIN.com,
         systemDomain FOUNDATION_SYSTEM_DOMAIN.com,
         usageServiceUrl httpsapp-usage.FOUNDATION_SYSTEM_DOMAIN.com,
         invitationsServiceUrl httpsp-invitations.FOUNDATION_SYSTEM_DOMAIN.com,
         logoutUrl httpslogin.FOUNDATION_SYSTEM_DOMAIN.comlogout.do,
         uaaUrl httpslogin.FOUNDATION_SYSTEM_DOMAIN
       },
     }')
```