### PR TITLE
No limitation for GCS compatibility with PASW

### DIFF
--- a/pas-file-storage.html.md.erb
+++ b/pas-file-storage.html.md.erb
@@ -1,9 +1,6 @@
 ---
 title: Configuring File Storage for PAS
 owner: Releng
-gcswarning: The Pivotal Application Service for Windows (PASW) tile is incompatible with Google Cloud Platform
- (GCP) configured with a Google Cloud Storage (GCS) filestore. If you are deploying PASW in your GCP
-  environment, Pivotal recommends that you select the S3-compatible filestore for your environment.
 ---
 
 This topic provides instructions for configuring file storage for PAS (Pivotal Application Service) based on your IaaS and installation method. See the section that applies to your use case.


### PR DESCRIPTION
The incompatibility was resolved 10 months back. So removing this from docs for all supported PAS versions.

Remove for all supported TAS versions. 