### PR TITLE
Update 2.9 docs to include support for vSphere 7.0

### DIFF
--- a/pas-vsphere-requirements.html.md.erb
+++ b/pas-vsphere-requirements.html.md.erb
@@ -20,7 +20,7 @@ The following are requirements for installing <%= vars.app_runtime_abbr %> that 
 
 The following are the minimum resource requirements for maintaining a [<%= vars.platform_name %>](https://network.pivotal.io/products/pivotal-cf) deployment with <%= vars.app_runtime_abbr %> on vSphere:
 
-* vSphere v6.7 or v6.5
+* vSphere v7.0, v6.7 or v6.5
 * Disk space: 2&nbsp;TB recommended
 * Memory: 120&nbsp;GB
 * Two public IP addresses: One for <%= vars.app_runtime_abbr %> and one for <%= vars.ops_manager %>


### PR DESCRIPTION
Ops Manager 2.9 shipped with a version of the vSphere CPI that supports vSphere 7.0. As such, we should add it to the compatibility list.