### PR TITLE
Updated file download instructions.

### DIFF
--- a/configure-pas.html.md.erb
+++ b/configure-pas.html.md.erb
@@ -24,8 +24,8 @@ To add the <%= vars.app_runtime_abbr %> tile to your <%= vars.ops_manager %> Ins
 1. If you have not already downloaded <%= vars.app_runtime_abbr %>, log in to [<%= vars.product_network %>](https://network.pivotal.io/products/pivotal-cf) and click **<%= vars.app_runtime_full %>**.
 
 1. From the **Releases** dropdown, select the release to install and choose one of the following:
-  1. Click **<%= vars.app_runtime_full %>** to download the <%= vars.app_runtime_abbr %> `.pivotal` file.
-  1. Click **Small Footprint <%= vars.app_runtime_abbr %>** to download the Small Footprint <%= vars.app_runtime_abbr %> `.pivotal` file. For more information, see [Getting Started with Small Footprint <%= vars.app_runtime_abbr %>](./small-footprint.html).
+  1. Click **<%= vars.app_runtime_full %>** to download the Pivotal Application Service `.pivotal` file.
+  1. Click **Small Footprint <%= vars.app_runtime_abbr %>** to download the Small Footprint PAS `.pivotal` file. For more information, see [Getting Started with Small Footprint <%= vars.app_runtime_abbr %>](./small-footprint.html).
 
 1. Navigate to the <%= vars.ops_manager %> Installation Dashboard.
 


### PR DESCRIPTION
**Change** : Updated file download instructions to Pivotal Application Service and Small Footprint PAS as shown on the network page.

**Rationale**: Eventhough the overall name of the PaaS service has changed, the network page with download links still reference it by the PCF or Small Footprint PAS name.

Applicable for 2.9 version onwards.The reference issue could be because of the markdown vars already set.