### PR TITLE
Remove redundant gorouter arch doc

### DIFF
--- a/gdpr.html.md.erb
+++ b/gdpr.html.md.erb
@@ -329,7 +329,7 @@ The Cloud Foundry API release contains several components, including the Cloud C
 
 ### <a id='routing'></a>Routing
 
-By default, the [Gorouter](../concepts/architecture/router.html) logs include the `X-Forwarded-For` header, which may include the originating client IP. Under GDPR, client IP addresses should be considered personal data.
+By default, the [Gorouter](../concepts/http-routing.html#http-headers) logs include the `X-Forwarded-For` header, which may include the originating client IP. Under GDPR, client IP addresses should be considered personal data.
 
 #### <a id='disable-client-ip-logging'></a> Disable Client IP Logging
 


### PR DESCRIPTION
## The Change
tl;dr: The information contained on that page was represented elsewhere and the page no longer needs to exist.

- the home for the majority of this content is in:
  - `docs-cloudfoundry-concepts/cf-routing-architecture.html`
  - `docs-cf-admin/troubleshooting-router-error-responses.html`

- Removes the following file and all links to file: `docs-cloudfoundry-concepts/architecture/router.html(.md.erb)`
- change link destinations to a more appropriate page
  - usually `docs-cloudfoundry-concepts/cf-routing-architecture.html`
- reorganize the flow of `docs-cloudfoundry-concepts/cf-routing-architecture.html`

PivotalTracker: [#174579096](https://www.pivotaltracker.com/story/show/174579096)

## Backports
Please backport these changes to TAS 2.7.

## Related PRs
- cloudfoundry/docs-cloudfoundry-concepts/pull/148
- cloudfoundry/docs-cf-admin/pull/193
- cloudfoundry/docs-book-cloudfoundry/pull/105
- pivotal-cf/docs-book-windows/pull/4
- pivotal-cf/docs-operating-pas/pull/40
- pivotal-cf/docs-partials/pull/29
- pivotal-cf/docs-pcf-windows/pull/73
- cloudfoundry/docs-routing/pull/3
- pivotal-cf/docs-tiledev/pull/106