### PR TITLE
Remove "Skip SSL Certificate Verification"

### DIFF
--- a/quickstart-pas.html.md.erb
+++ b/quickstart-pas.html.md.erb
@@ -46,8 +46,6 @@ To install <%= vars.app_runtime_abbr %> with minimal configuration:
   <p class="note"><strong>Note:</strong> If you configured <%= vars.ops_manager %> Front End without a certificate, you can use this new certificate to complete your <%= vars.ops_manager %> configuration. To configure your <%= vars.ops_manager %> Front End certificate, see <a href="https://docs.pivotal.io/pcf/om/gcp/prepare-env-manual.html#config-frontend">Configure Front End</a> in <em> Preparing to Deploy Ops Manager on GCP Manually</em>.</p>
   <p class="note"><strong>Note:</strong> Ensure that you add any certificates that you generate in this pane to your infrastructure load balancer.</p>
 
-1. <%# Find this partial in GitHub at `pivotal-cf/docs-partials` %><%= partial "/pcf/core/#{vars.current_major_version.sub('.', '-')}/ssl_verification" %>
-
 1. Disable the **HAProxy forwards all requests to the Gorouter over TLS** checkbox. By default, <%= vars.app_runtime_abbr %> does not deploy HAProxy.
 
 1. Setting appropriate ASGs is critical for a secure deployment. To acknowledge that you are responsible for setting the appropriate ASGs after the <%= vars.app_runtime_abbr %> deployment completes:


### PR DESCRIPTION
## The Change
- Makes `ha_proxy.skip_cert_verify` (Skip SSL Certificate Verification)
unconfigurable and defaulted to `false`
- Removes the form from the tile UI
- Adds migration to prevent upgrading when this feature is configured
`true`
- Removes all documentation referencing to this setting
- Updates Ops Man documentation for case when users want to provide
their own self-signed certificate

[#174811172](https://www.pivotaltracker.com/story/show/174811172)

Co-authored-by: Josh Russett <jrussett@vmware.com>
Co-authored-by: Ryan Hall <hallr@vmware.com>

## Backports
None

## Related PRs
#### Tiles
- pivotal-cf/p-runtime#1826
- pivotal-cf/p-isolation-segment#503
#### Docs
- pivotal-cf/docs-partials#31
- cloudfoundry/docs-cf-admin#194
- pivotal-cf/docs-operating-pas#41
- pivotal-cf/docs-pivotalcf-console#16