### PR TITLE
Update max-in-flight advice

### DIFF
--- a/configuring.html.md.erb
+++ b/configuring.html.md.erb
@@ -87,7 +87,7 @@ Some more precise guidelines include:
 
 * For other components, set `max_in_flight` to the number of instances that you can afford to have down at any one time. The best values for your deployment vary based on your capacity planning. In a highly redundant deployment, you can make the number high so that updates run faster. However, if your components are at high utilization, you should keep the number low to prevent downtime.
 
-* Never set `max_in_flight` to a value greater than or equal to the number of instances you have running for a component.
+* Setting `max_in_flight` to a value greater than or equal to the number of instances you have running may result in reduced functionality.
 
 
 ## <a id="container-starts"></a> Set a Maximum Number of Starting Containers


### PR DESCRIPTION
Not sure on ultimate wording, but we should be less absolute about our max in flight guidance given that some specific fixes may require or be better when max in flight is set higher. We have explicitly advised this in fixes. 

probubly should change in all versions. 