### PR TITLE
Wrong link for accessing metrics

### DIFF
--- a/monitoring/kpi.html.md.erb
+++ b/monitoring/kpi.html.md.erb
@@ -17,7 +17,7 @@ While the performance impact on TAS for VMs is considered when building new feat
 It is impossible to test each configuration of TAS for VMs with every type of infrastructure and app workload.
 Therefore, VMware recommends using the following KPIs to identify when to scale your system.
 
-For more information about accessing metrics used in these key performance indicators, see <a href="https://docs.pivotal.io/application-service/2-11/loggregator/data-sources.html">Overview of Logging and Metrics</a>.
+For more information about accessing metrics used in these key performance indicators, see <a href="https://docs.pivotal.io/application-service/2-12/loggregator/data-sources.html">Overview of Logging and Metrics</a>.
 
 ## <a id="auctioneer"></a> Diego Auctioneer Metrics
 


### PR DESCRIPTION
The link for accessing metrics is for TAS 2.11. It should be for TAS 2.12.