### PR TITLE
Feat: separate log cache

### DIFF
--- a/logging-config-opsman.html.md.erb
+++ b/logging-config-opsman.html.md.erb
@@ -142,9 +142,8 @@ To add component VM instances for Loggregator components:
 
 1. Increase the number in the **Instances** column of the component you want to scale. You can add instances for the following Loggregator components:
 	* **Loggregator Traffic Controller**
-		<p class="note"><strong>Note:</strong> The Reverse Log Proxy (RLP) BOSH job is colocated on the Traffic Controller VM. If you want to scale Loggregator to handle more logs for syslog drains, you can add instances of the Traffic Controller. For more information, see <a href="../loggregator/architecture.html">Loggregator Architecture</a>.</p>
-		<p class="note"><strong>Note:</strong> The BOSH System Metrics Forwarder</a> job is colocated on the Traffic Controller VM. If you want to scale Loggregator to handle more BOSH component metrics, you can add instances of the Traffic Controller. For more information, see <a href="../loggregator/architecture.html#bosh-metrics">Related BOSH Components</a> in <em>Loggregator Architecture</em>.</p>
 	* **Doppler Server**
+	* **Log Cache**
 
 1. Click **Save**.
 

--- a/monitoring/key-cap-scaling.html.md.erb
+++ b/monitoring/key-cap-scaling.html.md.erb
@@ -491,7 +491,7 @@ There is a single key capacity scaling indicator <%= vars.company_name %> recomm
     <tr>
       <th width="25">Description</th>
         <td> The Log Cache Caching Duration indicator shows the age in milliseconds of the oldest data point stored in Log Cache.<br>
-        Log Cache stores all messages that are passed through the Firehose in an ephemeral in-memory store. The size of this store and the cache duration are dependent on the amount of memory available on the VM where Log Cache runs. Typically, Log Cache runs on the Doppler VM. 
+        Log Cache stores all messages that are passed through the Firehose in an ephemeral in-memory store. The size of this store and the cache duration are dependent on the amount of memory available on the VM where Log Cache runs.
         </td>
     </tr>
     <tr>
@@ -512,7 +512,7 @@ There is a single key capacity scaling indicator <%= vars.company_name %> recomm
     </tr>
     <tr>
       <th>How to scale</th>
-        <td>Scale up the number of Doppler VMs or choose a VM type for Doppler that provides more memory.</td>
+        <td>Increase the number of Log Cache VMs in the Resource Config pane of the TAS for VMs tile, or choose a VM type that provides more memory.</td>
     </tr>
     <tr>
       <th>Additional details</th>


### PR DESCRIPTION
Log Cache is moving from the doppler VM to the log-cache VM