### PR TITLE
Correct Log Cache Syslog Server port

### DIFF
--- a/networking/loggregator-network-paths.html.md.erb
+++ b/networking/loggregator-network-paths.html.md.erb
@@ -41,7 +41,7 @@ The following table lists network communication paths for Log Cache:
 
 | Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
 | --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
-| Any VM running Loggregator Syslog Agent&#42; | log_cache | 6667 | TCP | Syslog | TLS |
+| Any VM running Loggregator Syslog Agent&#42; | log_cache | 6067 | TCP | Syslog | TLS |
 | Any&#42;&#42; | log_cache | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | log_cache (Nozzle)&#42;&#42;&#42; | loggregator_trafficcontroller (Reverse Log Proxy) | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | gorouter | log_cache (Auth Proxy) | 8083 | TCP | HTTP | OAuth |


### PR DESCRIPTION
We typoed when specifying the Log Cache Syslog Server port in an earlier PR. The [default port for Log Cache Syslog Server is 6067](https://github.com/cloudfoundry/log-cache-release/blob/757e009b80500aa164c6272266301d4af5fb879d/jobs/log-cache-syslog-server/spec#L31-L33).

Thanks!