### PR TITLE
add tas specific CPU entitlement doc

### DIFF
--- a/cpu-entitlement.html.md.erb
+++ b/cpu-entitlement.html.md.erb
@@ -1,0 +1,42 @@
+---
+title: CPU Entitlement
+owner: Diego
+---
+
+<% current_page.data.title = "CPU Entitlement" %>
+
+This topic describes how to CPU entitlements work in <%= vars.app_runtime_first %> and how to configure them.
+
+## <a id='overview'></a> Overview
+<%# Find this partial in GitHub at `pivotal-cf/docs-partials` %>
+<%= partial "/cpu-entitlement/overview" %>
+
+## <a id='cpu-entitlement-plugin'></a> CPU Entitlement Plugin
+<%# Find this partial in GitHub at `pivotal-cf/docs-partials` %>
+<%= partial "/cpu-entitlement/plugin" %>
+
+## <a id='spare-cpu-resources'></a> Spare CPU Resources and Throttling
+<%# Find this partial in GitHub at `pivotal-cf/docs-partials` %>
+<%= partial "/cpu-entitlement/spare-cpu-and-throttling" %>
+
+CPU Burst Optimization is turned off by default. You can check this setting by
+going to the App Containers tab and checking the property **Enable CPU Burst
+Optimization**
+
+### <a id='without-cpu-burst-optimization'></a> Without CPU Burst Optimization
+When CPU Burst Optimization is turned off, all apps on the cell share any spare
+CPU resources.
+
+### <a id='spare-cpu-resources'></a> With CPU Burst Optimization
+When CPU Burst Optimization is turned on, "good" apps get bursting priority
+over "bad" apps. Good apps are apps that, on average, have stayed within their
+CPU entitlement. Bad apps are apps that, on average, have exceeded their CPU
+entitlement.
+
+Imagine a Diego Cell with 5 bad apps and 1 good app. Initially the 5 "bad"
+apps will evenly split all of the spare CPU resources. If the good app needs
+to burst, it will be given priority to all of the extra CPU it needs. If the
+good app continues bursting for long enough and on average it exceeds its CPU
+entitlement, then it will become a bad app. Then all 6 "bad" apps will
+equally share the spare CPU resources. Likewise, if one of the bad apps stops
+using so much CPU it will become a good app again.


### PR DESCRIPTION
This PR is part of a group of 3 PRs.

* https://github.com/pivotal-cf/docs-partials/pull/87
  *  Adds partials about cpu-entitlement.
  *  Adds sidenav entries for the TAS specific cpu entitlement docs.
* https://github.com/cloudfoundry/docs-cf-admin/pull/221
  * Updates the open source CF cpu entitlement doc to use the partials. 
* https://github.com/pivotal-cf/docs-operating-pas/pull/106 👈 This PR
  * Creates the TAS specific cpu entitlement doc.
  * This doc uses the partials from the first PR.
  * And it is linked to in the sidenav by the first PR.
  
  
✨ Please let me know if you have any questions or if I need to fix anything!