### PR TITLE
Remove vSphere version requirements

### DIFF
--- a/pas-vsphere-requirements.html.md.erb
+++ b/pas-vsphere-requirements.html.md.erb
@@ -16,7 +16,6 @@ The following are requirements for installing <%= vars.app_runtime_abbr %> that 
 
 The following are the minimum resource requirements for maintaining a [<%= vars.platform_name %>](https://network.tanzu.vmware.com/products/ops-manager) deployment with <%= vars.app_runtime_abbr %> on vSphere:
 
-* vSphere v7.0, v6.7, or v6.5
 * Disk space: 2&nbsp;TB recommended
 * Memory: 120&nbsp;GB
 * Two public IP addresses: One for <%= vars.app_runtime_abbr %> and one for <%= vars.ops_manager %>


### PR DESCRIPTION
When the TAS and Ops Manager documentation was combined, it made sense to document the vSphere version here. However, they are now split, and the vSphere version is only relevant to the Ops Manager documentation.

Related PR to add the vSphere version to the Ops Manager documentation: https://github.com/pivotal-cf/docs-ops-manager/pull/245