### PR TITLE
Remove outdated gorouter scaling advice

### DIFF
--- a/monitoring/key-cap-scaling.html.md.erb
+++ b/monitoring/key-cap-scaling.html.md.erb
@@ -572,7 +572,7 @@ formats:</p>
     <tr>
       <th>How to scale</th>
         <td>
-        Scale the Gorouters horizontally or vertically by editing the Router VM in the Resource Config pane of the TAS for VMs tile. At greater than 8 CPUs, vertical scaling is no longer beneficial for increasing throughput.
+        Scale the Gorouters horizontally or vertically by editing the Router VM in the Resource Config pane of the TAS for VMs tile.
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
Many years ago the limit of scaling gorouters past 8 CPU was removed via [this commit ](https://github.com/cloudfoundry/gorouter/commit/1daba6ff22804633db006272359f514583e2eac6). It has been verified that vertical scaling past 8 CPUs _does_ have a positive affect on throughput.