### PR TITLE
Log Cache can now be configured for mTLS

### DIFF
--- a/networking/loggregator-network-paths.html.md.erb
+++ b/networking/loggregator-network-paths.html.md.erb
@@ -41,7 +41,7 @@ The following table lists network communication paths for Log Cache:
 
 | Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
 | --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
-| Any VM running Loggregator Syslog Agent&#42; | log_cache | 6067 | TCP | Syslog | TLS |
+| Any VM running Loggregator Syslog Agent&#42; | log_cache | 6067 | TCP | Syslog | TLS or Mutual TLS (configurable) |
 | Any&#42;&#42; | log_cache | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | log_cache (Nozzle)&#42;&#42;&#42; | loggregator_trafficcontroller (Reverse Log Proxy) | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | gorouter | log_cache (Auth Proxy) | 8083 | TCP | HTTP | OAuth |


### PR DESCRIPTION
Clarify that communication between the syslog agent and log cache syslog server can be TLS or mTLS depending on the operator configuration (from TAS 5.0).