### PR TITLE
Configure system logging changes for IST 5.0

### DIFF
--- a/installing-pcf-is.html.md.erb
+++ b/installing-pcf-is.html.md.erb
@@ -138,6 +138,12 @@ For more information about RainerScript, see the [RainerScript](http://www.rsysl
 
 1. Select the **Enable system metrics** check box to emit system-level metrics about all VMs in the deployment. For a list of the VM metrics that the System Metric Agent emits, see [System Metrics Agent](https://github.com/cloudfoundry/system-metrics-release/blob/main/docs/system-metrics-agent.md) in GitHub. When you activate this check box, ensure that you open port `53035` for the isolation segment. For more information, see [Configure Firewall Rules](../adminguide/routing-is.html#config-firewall) in _Routing for Isolation Segments_.
 
+1. (Optional) For **OpenTelemetry Collector Metric Exporters (beta)**, the default value is empty, which disables the beta OpenTelemetry Aggregate Metric Egress
+support. To configure the <%= vars.segment_runtime_full %> tile to send metrics over the OpenTelemetry protocol, enter valid OpenTelemetry Collector Exporter YAML
+configuration in this field. Refer to the [OpenTelemetry Collector documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) for examples
+of how to configure exporters. Currently the <%= vars.segment_runtime_full %> tile provides support for a limited number of OpenTelemetry Collector Exporters,
+including the OTLP exporter. Note that this feature is in beta and may still change in significant ways.
+
 1. Click **Save**.
 
 ### <a id='advanced_features'></a> Configure advanced features

--- a/installing-pcf-is.html.md.erb
+++ b/installing-pcf-is.html.md.erb
@@ -136,8 +136,6 @@ To configure the **System Logging** pane:
 1. (Optional) To specify a custom syslog rule, enter it in the **Custom rsyslog configuration** field in RainerScript syntax. For more information about customizing syslog rules, see [Customizing Syslog Rules](./custom-syslog-rules.html).
 For more information about RainerScript, see the [RainerScript](http://www.rsyslog.com/doc/v8-stable/rainerscript/index.html) documentation.
 
-1. Select the **Enable system metrics** check box to emit system-level metrics about all VMs in the deployment. For a list of the VM metrics that the System Metric Agent emits, see [System Metrics Agent](https://github.com/cloudfoundry/system-metrics-release/blob/main/docs/system-metrics-agent.md) in GitHub. When you activate this check box, ensure that you open port `53035` for the isolation segment. For more information, see [Configure Firewall Rules](../adminguide/routing-is.html#config-firewall) in _Routing for Isolation Segments_.
-
 1. (Optional) For **OpenTelemetry Collector Metric Exporters (beta)**, the default value is empty, which disables the beta OpenTelemetry Aggregate Metric Egress
 support. To configure the <%= vars.segment_runtime_full %> tile to send metrics over the OpenTelemetry protocol, enter valid OpenTelemetry Collector Exporter YAML
 configuration in this field. Refer to the [OpenTelemetry Collector documentation](https://opentelemetry.io/docs/collector/configuration/#exporters) for examples


### PR DESCRIPTION
* Document new otel collector metric egress support
* Remove reference to long-removed "Enable system metrics" check box (effectively moved to Ops Manager)