### PR TITLE
Remove note on 'Enable system metrics' check box (4.0)

### DIFF
--- a/installing-pcf-is.html.md.erb
+++ b/installing-pcf-is.html.md.erb
@@ -143,8 +143,6 @@ To configure the **System Logging** pane:
 1. (Optional) To specify a custom syslog rule, enter it in the **Custom rsyslog configuration** field in RainerScript syntax. For more information about customizing syslog rules, see [Customizing Syslog Rules](./custom-syslog-rules.html).
 For more information about RainerScript, see the [RainerScript](http://www.rsyslog.com/doc/v8-stable/rainerscript/index.html) documentation.
 
-1. Select the **Enable system metrics** check box to emit system-level metrics about all VMs in the deployment. For a list of the VM metrics that the System Metric Agent emits, see [System Metrics Agent](https://github.com/cloudfoundry/system-metrics-release/blob/main/docs/system-metrics-agent.md) in GitHub. When you activate this check box, ensure that you open port `9100` for the isolation segment. For more information, see [Configure Firewall Rules](../adminguide/routing-is.html#config-firewall) in _Routing for Isolation Segments_.
-
 1. Click **Save**.
 
 ### <a id='advanced_features'></a> Configure advanced features


### PR DESCRIPTION
This option was removed in IST 2.9 as enabling system metrics is now controlled within Ops Manager's configuration.

For example:
https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/vmware-tanzu-ops-manager/vsphere-config.html#step-3-director-config-pane-3

Signed-off-by: Carson Long <lcarson@vmware.com>
(cherry picked from commit 59caeba7ef33dda66ba2b2f47a58733199774437)