### PR TITLE
Add warning for potential port conflicts

### DIFF
--- a/installing-pcf-is.html.md.erb
+++ b/installing-pcf-is.html.md.erb
@@ -142,6 +142,9 @@ configuration in this field. See the [OpenTelemetry Collector documentation](htt
 of how to configure exporters. Currently the <%= vars.segment_runtime_full %> tile provides support for a limited number of OpenTelemetry Collector Exporters,
 including the OTLP exporter. This feature is in beta and may still change in significant ways.
 
+  <p class='note warning'><strong>Caution:</strong> If configuring a metric exporter that listens on a port, take care to ensure that the port is not claimed by
+  a <%= vars.segment_runtime_full %> component on any of the VMs in your deployment.</p>
+
 1. Click **Save**.
 
 ### <a id='advanced_features'></a> Configure advanced features


### PR DESCRIPTION
- There is potential for a metric exporter to listen on a port that a system component needs to use.
- Ideally we might link here to a port reference for all ports in use within the Isolation Segment tile.
- I believe our docs on port usage are focused on configuration of firewall rules. Here the operator may need to ensure that they also don't conflict with system components that only listen on the local interface.