### PR TITLE
fix: wrong instructions about custom branding configs

### DIFF
--- a/custom-branding.html.md.erb
+++ b/custom-branding.html.md.erb
@@ -23,11 +23,11 @@ To customize your Apps Manager interface:
 
 1. For **Accent color**, enter the hexadecimal code for the color used to accent various visual elements, such as the currently selected space in the sidebar. For example, `#71ffda`.
 
-1. For **Main logo**, enter a Base64 encoded URL string for a PNG image to use as your main logo. The image can be square or wide. For example, `data:image/png;base64,iVBORw0...`. If left blank, the image defaults to the <%= vars.company_name %> logo.
+1. For **Main logo**, enter a Base64 encoded URL string for a PNG image, leaving out the mime-type (`data:image/png;base64,`), to use as your main logo. The image can be square or wide. If left blank, the image defaults to the <%= vars.company_name %> logo.
 
-1. For **Square logo**, enter a Base64 encoded URL string for a PNG image to use in the Apps Manager header and in places that require a smaller logo. For example, `data:image/png;base64,iVBORw0...`. If left blank, the image defaults to the <%= vars.company_name %> logo.
+1. For **Square logo**, enter a Base64 encoded URL string for a PNG image, leaving out the mime-type (`data:image/png;base64,`), to use in the Apps Manager header and in places that require a smaller logo. If left blank, the image defaults to the <%= vars.company_name %> logo.
 
-1. For **Favicon**, enter a Base64 encoded URL string for a PNG image to use as your favicon. For example, `data:image/png;base64,iVBORw0...`. If left blank, the image defaults to the <%= vars.company_name %> logo.
+1. For **Favicon**, enter a Base64 encoded URL string for a PNG image, leaving out the mime-type (`data:image/png;base64,`), to use as your favicon. If left blank, the image defaults to the <%= vars.company_name %> logo.
 
 1. For **Footer text**, enter a string to be displayed as the footer. If left blank, the footer text defaults to **<%= vars.company_name %> Software, Inc; All rights reserved.**
 


### PR DESCRIPTION
- The current help text in TAS Tile UI says "Enter a base64-encoded PNG image string, leaving out the mime-type (data:image/png;base64,) string." for these 3 fields. This is the correct instruction.
- However, previously, this doc gives some examples that do include the mime-type (data:image/png;base64,), which is incorrect and contradicts the TAS Tile UI help text.
- Hence, this commit removes the incorrect examples and clarifies that the mime-type (data:image/png;base64,) needs to be left out.

[Tracker story: https://www.pivotaltracker.com/story/show/185959519]