### PR TITLE
upgrade from small footprint: replace staging with production url

### DIFF
--- a/upgrading-from-small-footprint.html.md.erb
+++ b/upgrading-from-small-footprint.html.md.erb
@@ -10,7 +10,7 @@ If you have installed Small Footprint <%= vars.app_runtime_full %>, you can upgr
 This feature is only available in <%= vars.app_runtime_abbr %> v6.0.1 and later.
 </p>
 
-For more information about choosing between Small Footprint and full <%= vars.app_runtime_abbr %>, see [When should you use Small Footprint TAS for VMs?](https://docs-staging.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/toc-tas-install-index.html#when-should-you-use-small-footprint-tas-for-vms-0) in _Installing TAS for VMs_.
+For more information about choosing between Small Footprint and full <%= vars.app_runtime_abbr %>, see [When should you use Small Footprint TAS for VMs?](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/toc-tas-install-index.html#when-should-you-use-small-footprint-tas-for-vms-0) in _Installing TAS for VMs_.
 
 ## <a id='preserving-data'></a> Preserving data after the upgrade
 


### PR DESCRIPTION
this replaces a staging link to the "when should you use SF" content with the production link. (ideally, we would have used a relative link there, but that content appears on a toc page, which is very tricky to link to from a content topic, so it's an absolute url and will have to be updated for each new major or minor TAS release.)

this change will need to be cherry-picked to 6.0.