### PR TITLE
Update CAPI v2 docs links to new subdomain

### DIFF
--- a/accounting-report.html.md.erb
+++ b/accounting-report.html.md.erb
@@ -6,7 +6,7 @@ owner: BAM
 You can use the Cloud Foundry Command Line Interface (cf CLI) to retrieve historical system-level and org-level usage information about your <%= vars.app_runtime_abbr %> apps, tasks, and service instances through the Cloud Controller and Usage Service APIs.
 
 Usage reports are compiled from the `/v2/app_usage_events` endpoint.
-For more information, see [List all app usage events](https://apidocs.cloudfoundry.org/6.7.0/app_usage_events/list_all_app_usage_events.html) in the Cloud Foundry API documentation.
+For more information, see [List all app usage events](https://v2-apidocs.cloudfoundry.org/app_usage_events/list_all_app_usage_events.html) in the Cloud Foundry API documentation.
 
 You can also access usage information by using Apps Manager.
 For more information, see [Reporting instance usage with Apps Manager](accounting-report-apps-man.html).


### PR DESCRIPTION
This PR updates CAPI v2 docs links from `apidocs.cloudfoundry.org` to `v2-apidocs.cloudfoundry.org`.
The goal is to signal that v3 is the primary API, also a necessary step in eventually sunsetting v2.

The infrastructure hosting the app serving docs at apidocs.cloudfoundry.org is expected to go down imminently, so this change is needed to avoid dead links.

See capi-release PRs [#440](https://github.com/cloudfoundry/capi-release/pull/440) and [#441](https://github.com/cloudfoundry/capi-release/pull/441)